### PR TITLE
Refactoring/43 category Category 리팩토링 및 반환 형식 수정

### DIFF
--- a/src/category/category.controller.ts
+++ b/src/category/category.controller.ts
@@ -19,7 +19,7 @@ export class CategoryController {
   @Post()
   async create(@Body() createCategoryDto: CreateCategoryDto, @Request() req) {
     const userId = req.user.userId
-    return this.categoryService.create(createCategoryDto, userId);
+    return await this.categoryService.create(createCategoryDto, userId);
   }
 
   @ApiOperation({
@@ -29,7 +29,7 @@ export class CategoryController {
   @Get()
   async findAll(@Request() req) {
     const userId = req.user.userId
-    return this.categoryService.findAll(userId)
+    return await this.categoryService.findAll(userId)
   }
 
   @ApiOperation({
@@ -39,7 +39,7 @@ export class CategoryController {
   @Get(':id')
   async findCategory(@Param('id', ParseIntPipe) categoryId: number, @Request() req) {
     const userId = req.user.userId
-    return this.categoryService.findOne(categoryId, userId)
+    return await this.categoryService.findOne(categoryId, userId)
   }
 
   @ApiOperation({
@@ -50,7 +50,7 @@ export class CategoryController {
   @Post(':id')
   async updateCategory(@Param('id', ParseIntPipe) categoryId: number, @Request() req, @Body() updateCategoryDto: UpdateCategoryDto){
     const userId = req.user.userId
-    return this.categoryService.updateCategory(categoryId, userId, updateCategoryDto)
+    return await this.categoryService.updateCategory(categoryId, userId, updateCategoryDto)
   }
 
   @ApiOperation({
@@ -60,6 +60,6 @@ export class CategoryController {
   @Delete(':category_id')
   async deleteCategory(@Param('category_id', ParseIntPipe) categoryId: number, @Request() req) {
     const userId = req.user.userId;
-    return this.categoryService.deleteCategory(categoryId, userId);
+    return await this.categoryService.deleteCategory(categoryId, userId);
   }
 }

--- a/src/common/types/response.type.ts
+++ b/src/common/types/response.type.ts
@@ -1,0 +1,20 @@
+type ResultType = 'success' | 'error' | 'fail';
+
+interface BaseResponse {
+    result: ResultType;
+}
+
+interface SuccessResponse<T=any> extends BaseResponse {
+    result: 'success';
+    data: T;
+}
+
+interface FailResponse extends BaseResponse {
+    result: 'fail';
+    message: string;
+}
+
+interface ErrorResponse extends BaseResponse {
+    result: 'error';
+    message: string
+}


### PR DESCRIPTION
## 개요 📖

카테고리 리팩토링 작업
기존의 카테고리 반환 형태가 다양하여 이에 대한 피드백을 받아서 리팩토링 진행.

반환 해야 할 데이터가 있으면 기존에는 data를 그대로  보내고,
에러 메시지 발생 시 메시지를 그대로 보내는 형태였음.
이를 아래와 같이 3가지 타입으로 나누어서 수정

우선 category에 적용 후 다른 부분에서도  하나씩 리팩토링 진행 예정.

### 성공 시
```
result: 'success',
data: {반환 데이터}
```

### 실패 시
```
result: 'fail',
message: "실패 메시지"
```

### 에러 시
```
result: 'error',
message: "에러 메시지"
```


## 관련 이슈 📄

- Close #43 