### PR TITLE
Refactoring/42 auth api 응답 수정

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -65,7 +65,7 @@ export class AuthController {
   }
 
   @ApiOperation({
-    summary: "Apple 회원 탈퇴 API",
+    summary: "회원 탈퇴 API",
     description: "회원 탈퇴 API입니다."
   })
   @ApiBearerAuth()

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -22,7 +22,7 @@ export class AuthController {
   @ApiBody({ type: AuthGoogleLoginBody })
   @ApiResponse({ type: AuthLoginResponse })
   async googleLogin(@Body('token') token: string) {
-    return this.authService.googleLogin(token);
+    return await this.authService.googleLogin(token);
   }
 
   @ApiOperation({
@@ -33,7 +33,7 @@ export class AuthController {
   @ApiBody({ type: AuthAppleLoginBody })
   @ApiResponse({ type: AuthLoginResponse })
   async appleLogin(@Body('token') token: string ) {
-    return this.authService.appleLogin(token);
+    return await this.authService.appleLogin(token);
   }
 
   @ApiOperation({
@@ -44,7 +44,7 @@ export class AuthController {
   @ApiBody({ type: AuthRefreshTokenBody })
   @ApiResponse({ type: AuthLoginResponse })
   async login(@Body('refreshToken') refresh_token: string) {
-    return this.authService.refreshToken(refresh_token);
+    return await this.authService.refreshToken(refresh_token);
   }
 
   @ApiOperation({
@@ -73,6 +73,6 @@ export class AuthController {
   @Delete()
   async withdraw(@Request() req) {
     const userId = req.user.userId;
-    return this.authService.withdraw(userId)
+    return await this.authService.withdraw(userId)
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -283,41 +283,38 @@ export class AuthService {
   }
 
   // 유저 정보 반환해주는 함수
-  async getUserInfo(userId: number) {
+  async getUserInfo(userId: number): Promise<SuccessResponse | FailResponse | ErrorResponse> {
     try {
       let isVerifiedUser = await this.prisma.user.findUnique({
         where: {
           user_id: userId
         }
       })
+      // 유저가 존재한지 체크
       if (isVerifiedUser) {
-        const userPlant = await this.prisma.user_plants.findFirst({
-          where: {
-            user_id: isVerifiedUser.user_id,
-            plants_is_done: false
-          }
-        });
-
-        const plant = await this.prisma.plants.findUnique({
-          where: {
-            plant_id: userPlant?.plant_id
-          }
-        });
-
         return {
-          user: isVerifiedUser,
-          userPlant: userPlant,
-          plant: plant
+          result: 'success',
+          data: isVerifiedUser
         }
       } else {
-        throw new UnauthorizedException("INVALID_TOKEN")
+        return {
+          result: 'fail',
+          message: 'DATA NOT FOUND'
+        }
       }
     } catch(error) {
       console.log(error);
       if (error.name == "TokenExpiredError") {
-        throw new UnauthorizedException("EXPIRED_TOKEN")
+        return {
+          result: 'fail',
+          message: 'EXPIRED_TOKEN'
+        }
       }
-      throw new UnauthorizedException("INVALID_TOKEN")
+
+      return {
+        result: 'error',
+        message: 'INVALID_REQUEST'
+      }
     }
   }
 


### PR DESCRIPTION
## 개요 📖

auth 리팩토링 작업

아래와 같은 공통 방식의 응답으로 수정
auth info에서 너무 많은 정보를 반환해준다 하여, 이를 계정 하나로 줄이도록 수정

### 성공 시
```
result: 'success',
data: {반환 데이터}
```

### 실패 시
```
result: 'fail',
message: "실패 메시지"
```

### 에러 시
```
result: 'error',
message: "에러 메시지"
```


## 관련 이슈 📄

- Close #42 