### PR TITLE
Chore/41 completed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "axios": "^1.7.9",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "dayjs": "^1.11.13",
         "fastify-swagger": "^5.1.1",
         "firebase-admin": "^13.1.0",
         "google-auth-library": "^9.15.1",
@@ -5808,6 +5809,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "axios": "^1.7.9",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "dayjs": "^1.11.13",
     "fastify-swagger": "^5.1.1",
     "firebase-admin": "^13.1.0",
     "google-auth-library": "^9.15.1",

--- a/src/completed/completed.controller.ts
+++ b/src/completed/completed.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, UseGuards, Request, Patch, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { CompletedService } from './completed.service';
-import { ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { AuthJWTGuard } from 'src/auth/auth.jwt.guard';
 
 @UseGuards(AuthJWTGuard)
@@ -24,6 +24,21 @@ export class CompletedController {
     description: "complete_todo_id 값을 id값으로 입력하면 해당 completed_todo 완료 여부가 toggle 됩니다."
   })
   @Patch(':id')
+  @ApiResponse({
+    schema: {
+      properties: {
+        type: {
+          description: '경험치가 가득 차 식물이 바뀌는 경우에만 LEVEL_UP을 반환, 나머지 케이스에서는 SUCCESS 반환.',
+          example: 'SUCCESS | LEVEL_UP'
+        },
+        next_plant_id: {
+          description: 'type이 LEVEL_UP 시 유저 식물 ID 반환, SUCCESS 시 반환되지 않음',
+          example: '유저 식물 ID'
+        }
+      }
+    }
+  })
+
   async completedToggle(@Param('id', ParseIntPipe) id: number, @Request() req) {
     const userId = req.user.userId;
     return await this.completedService.toggleTodoCompletion(id, userId);

--- a/src/completed/completed.controller.ts
+++ b/src/completed/completed.controller.ts
@@ -13,7 +13,7 @@ export class CompletedController {
     summary: "금일 Completed TODO 목록 조회",
     description: "금일 TODO 목록 조회 API 입니다. completed todo를 조회해줍니다."
   })
-  @Get()
+  @Get('/today')
   async todayTodos(@Request() req) {
     const userId = req.user.userId
     return await this.completedService.todayTodosGet(userId)

--- a/src/completed/completed.service.ts
+++ b/src/completed/completed.service.ts
@@ -198,20 +198,20 @@ export class CompletedService {
   }
 
   // 특정 기간 동안 조회
-  async getTodoByDateRange(start_date_string: string, end_date_string: string, userId: number): Promise<SuccessResponse | FailResponse | ErrorResponse> {
+  async getTodoByDateRange(startDateString: string, endDateString: string, userId: number): Promise<SuccessResponse | FailResponse | ErrorResponse> {
     try {
-      if (start_date_string && end_date_string) {
-        const start_date = new Date(start_date_string);
-        const end_date = new Date(end_date_string);
+      if (startDateString && endDateString) {
+        const startDate = dayjs(startDateString).startOf('day').toDate();
+        const endDate = dayjs(endDateString).add(1, 'day').toDate();
 
         const todos = await this.prisma.todos.findMany({
           where: {
             user_id: userId,
             start_date: {
-              lte: start_date
+              lte: endDate
             },
             end_date: {
-              gt: end_date
+              gte: startDate
             }
           }
         });
@@ -223,9 +223,9 @@ export class CompletedService {
               in: todoIds
             },
             complete_at: {
-              gte: start_date,
-              lt: end_date
-            }
+              gte: startDate,
+              lt: endDate
+            },
           }
         });
 

--- a/src/completed/completed.service.ts
+++ b/src/completed/completed.service.ts
@@ -12,16 +12,13 @@ export class CompletedService {
 
   // 오늘 TODO 목록 가져오기
   // 타임존 문제가 있어서 시간이 이상하다. 한국 기준으로 하고 싶은데, 이것을 한국 기준으로 수정해서 하는것이 옳은지 모르겠다.
-  async todayTodosGet(user_id: number): Promise<SuccessResponse | FailResponse | ErrorResponse> {
+  async todayTodosGet(userId: number): Promise<SuccessResponse | FailResponse | ErrorResponse> {
     try {
       // 금일 설정
       dayjs.extend(utc);
       dayjs.extend(timezone);
       
-      const nowKST = dayjs().tz('Asia/Seoul');
-      
       const startOfToday = dayjs().tz('Asia/Seoul').startOf('day');
-
       const endOfToday = startOfToday.add(1, 'day');
 
       const startDate = startOfToday.toDate();
@@ -30,7 +27,7 @@ export class CompletedService {
       // 아직 마감안된 TODO 조회
       let todos = this.prisma.todos.findMany({
         where: {
-          user_id: user_id,
+          user_id: userId,
           start_date: {
             lte: endDate
           },
@@ -69,39 +66,39 @@ export class CompletedService {
   }
 
   // 완료 여부 변경
-  async toggleTodoCompletion(complete_todo_id: number, user_id: number): Promise<SuccessResponse | FailResponse | ErrorResponse> {
+  async toggleTodoCompletion(completeTodoId: number, userId: number): Promise<SuccessResponse | FailResponse | ErrorResponse> {
       try {
-        const completed_todo = await this.prisma.complete_todos.findUnique({
+        const completedTodo = await this.prisma.complete_todos.findUnique({
           where: {
-            complete_todo_id: complete_todo_id
+            complete_todo_id: completeTodoId
           },
         });
 
         const todo = await this.prisma.todos.findUnique({
           where: {
-            todo_id: completed_todo?.todo_id,
-            user_id: user_id
+            todo_id: completedTodo?.todo_id,
+            user_id: userId
           }
         });
 
-        if (todo && todo?.todo_id == completed_todo?.todo_id) {
+        if (todo && todo?.todo_id == completedTodo?.todo_id) {
           // 식물 경험치 추가
-          const exp = (completed_todo.is_done) ? -1 : 1;
+          const exp = (completedTodo.is_done) ? -1 : 1;
 
           // completed_todo 업데이트
           await this.prisma.complete_todos.update({
             where: {
-              complete_todo_id: complete_todo_id
+              complete_todo_id: completeTodoId
             },
             data: {
-              is_done: !completed_todo.is_done
+              is_done: !completedTodo.is_done
             }
           });
 
           // 유저 식물 정보 가져오기
-          const user_plant = await this.prisma.user_plants.findFirst({
+          const userPlant = await this.prisma.user_plants.findFirst({
             where: {
-              user_id: user_id,
+              user_id: userId,
               plants_is_done: false
             }
           });
@@ -109,15 +106,15 @@ export class CompletedService {
           // 식물 정보 가져오기
           const plant = await this.prisma.plants.findUnique({
             where: {
-              plant_id: user_plant?.plant_id
+              plant_id: userPlant?.plant_id
             }
           });
 
           // 식물 경험치 다 채운 경우
-          if ((plant && user_plant) && (plant.max_exp <= (user_plant.exp + exp))) {
+          if ((plant && userPlant) && (plant.max_exp <= (userPlant.exp + exp))) {
             await this.prisma.user_plants.update({
               where: {
-                user_plant_id: user_plant.user_plant_id
+                user_plant_id: userPlant.user_plant_id
               },
               data: {
                 exp: {
@@ -130,7 +127,7 @@ export class CompletedService {
             // 새 식물 생성 후 전달
             const updatedUserPlant = await this.prisma.user_plants.create({
               data: {
-                user_id: user_id,
+                user_id: userId,
                 plant_id: plant.next_plant_id
               }
             });
@@ -138,47 +135,28 @@ export class CompletedService {
             // 새 식물 유저 테이블에도 업로드
             await this.prisma.user.update({
               where: {
-                user_id: user_id
+                user_id: userId
               },
               data: {
                 user_plant_id: updatedUserPlant.user_plant_id
               }
             })
 
-            // 새 식물에 대한 데이터
-            const updatedPlant  = await this.prisma.plants.findUnique({
-              where: {
-                plant_id: updatedUserPlant.plant_id
-              }
-            });
-
             return {
               result: 'success',
               data: {
-                userPlant: updatedUserPlant,
-                plant: updatedPlant
+                type: 'LEVEL_UP',
+                next_plant_id: updatedUserPlant.plant_id
               }
             }
           }
 
           // 식물 경험치 다 채우지 않은 경우
           else {
-            const updatedPlant = await this.prisma.user_plants.update({
-              where: {
-                user_plant_id: user_plant?.user_plant_id
-              },
-              data: {
-                exp: {
-                  increment: exp
-                }
-              }
-            });
-
             return {
               result: 'success',
               data: {
-                userPlant: updatedPlant,
-                plant: plant
+                type: 'SUCCESS'
               }
             }
           }


### PR DESCRIPTION
## 개요 📖

completed API 수정

아래와 같은 공통 방식의 응답으로 수정

### 성공 시
```
result: 'success',
data: {반환 데이터}
```

### 실패 시
```
result: 'fail',
message: "실패 메시지"
```

### 에러 시
```
result: 'error',
message: "에러 메시지"
```

또 기존 completed toggle 응답이 식물 정보 자체를 반환했지만,
레벨업 시에만 바뀐 유저 식물 ID를 반환하도록 수정.

식물 레벨업 안했을 때
```
result: 'success',
'data': {
    'type': 'SUCCESS'
}
```

식물 레벨업 시
```
'result': 'success',
data: {
    'type': 'LEVEL_UP',
    'next_plant_id': 유저 식물 ID
}
```
와 같은 방식으로 반환하도록 수정

## 관련 이슈 📄

- Close #40 
- Close #41 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of date and time for completed TODOs, now accurately reflecting the user's timezone (Asia/Seoul).
  - Enhanced API responses for toggling TODO completion, including clear status messages and plant level-up notifications.

- **Bug Fixes**
  - Fixed potential issues with date calculations by using a timezone-aware library.

- **Style**
  - Improved response structure and naming consistency in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->