### PR TITLE
[feat] v1.1.0 업데이트

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -128,6 +128,7 @@ export class AuthService {
         let userPlant = await this.prisma.user_plants.create({
           data: {
             user_id: user.user_id,
+            exp: 89
           },
         });
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -35,7 +35,7 @@ export class AuthService {
 
   private async createAccessToken(payload: Payload): Promise<string> {
     const accessToken = this.jwtService.sign(payload, {
-       expiresIn: '3h',
+       expiresIn: '1d',
        secret: process.env.SECRET_KEY
       });
     return accessToken

--- a/src/todos/dto/create.todo.body.dto.ts
+++ b/src/todos/dto/create.todo.body.dto.ts
@@ -1,7 +1,8 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNumber, IsString } from "class-validator";
+import { IsNumber, IsOptional, IsString } from "class-validator";
 
 export class CreateTodoBodyDto {
+    // --------------필수--------------
     @ApiProperty({
         description: "TODO 제목"
     })
@@ -9,32 +10,37 @@ export class CreateTodoBodyDto {
     title: string;
 
     @ApiProperty({
-        description: "TODO 상세 설명",
-        example: ""
-    })
-    description: string | null;
-    
-    @ApiProperty({
-        description: "카테고리 Number"
-    })
-    @IsNumber()
-    user_category_id: number | null;
-
-    @ApiProperty({
         description: "현재 식물 ID"
     })
     @IsNumber()
     user_plant_id: number;
-    
+
+    // --------------옵셔널--------------
+    @ApiProperty({
+        description: "카테고리 Number"
+    })
+    @IsOptional()
+    @IsNumber()
+    user_category_id: number | null;
+
+    @ApiProperty({
+        description: "TODO 상세 설명",
+        example: ""
+    })
+    @IsOptional()
+    description: string | null;
+
     @ApiProperty({
         description: "TODO 시작일",
         format: "date"
     })
-    start_date: Date;
+    @IsOptional()
+    start_date: Date | null;
     
     @ApiProperty({
         description: "TODO 마감일",
         format: "date"
     })
-    end_date: Date;
+    @IsOptional()
+    end_date: Date | null;
 }

--- a/src/todos/todos.service.ts
+++ b/src/todos/todos.service.ts
@@ -34,14 +34,18 @@ export class TodosService {
         });
       }
 
-      const startDate = new Date(createTodoDto.start_date);
-      const endDate = new Date(createTodoDto.end_date);
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      // 날짜 값이 따로 없으면 today로 삽입
+      const startDate = createTodoDto.start_date ? new Date(createTodoDto.start_date) : new Date(today);
+      const endDate = createTodoDto.end_date ? new Date(createTodoDto.end_date) : new Date(today);
 
       if (userPlant && userCategory) {
         const todo = await this.prisma.todos.create({
           data: {
             title: createTodoDto.title,
-            description: createTodoDto.description,
+            description: createTodoDto.description ?? null,
             start_date: startDate,
             end_date: endDate,
             user_id: userId,


### PR DESCRIPTION
## 개요 📖

- TODO 생성 Validation 수정
- AccessToken 기간 3h -> 1D 연장
- 처음 식물 경험치 89로 수정

## 관련 이슈 📄

- #62 
- #63 
- #64 

### #62

기존 TODO 생성을 위한 값들의 조건을 변경

# 변경 전
```
[필수]
- title
- user_plant_id
- start_date
- end_date

[옵션]
- description
- user_category_id
```

# 변경 후
```
[필수]
- title
- user_plant_id

[옵션]
- description
- user_category_id
- start_date
- end_date
```

### #63

기존 TODO 체크 하는것이 Toggle 형태이기 때문에, 한번 더 호출하면 서버딴 로직에서 처리하여 결과를 반환함.

### #64

원인 분석 결과

앱 이슈로 확인.

서버에서는 AccessToken의 기한을 연장하는 방식으로 추가적인 조치를 취함.

@wn-na 